### PR TITLE
fix integrity check fail and windows issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ cd signal-styler
 makepkg -si
 ```
 
+### Option 3: Run from source (**for developers**)
+
+Only do this to test new features before releases or for contributing.
+
+```bash
+git clone https://github.com/m-obeid/signal-styler.git
+cd signal-styler
+npm install -g pnpm # if not working try sudo or install through your package manager
+pnpm install
+node . -v # run node . instead of signal-styler
+```
+
 ---
 
 ## 🚀 Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signal-styler",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Add custom CSS to Signal Desktop",
   "main": "index.js",
   "bin": {
@@ -15,6 +15,8 @@
   "packageManager": "pnpm@10.15.0",
   "dependencies": {
     "@electron/asar": "^4.0.1",
-    "argparse": "^2.0.1"
+    "argparse": "^2.0.1",
+    "plist": "^3.1.0",
+    "resedit": "^3.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       argparse:
         specifier: ^2.0.1
         version: 2.0.1
+      plist:
+        specifier: ^3.1.0
+        version: 3.1.0
+      resedit:
+        specifier: ^3.0.1
+        version: 3.0.1
 
 packages:
 
@@ -34,6 +40,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@xmldom/xmldom@0.8.11':
+    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+    engines: {node: '>=10.0.0'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -52,6 +62,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -120,6 +133,18 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
+  pe-library@2.0.1:
+    resolution: {integrity: sha512-/qjYFqNSlq59B5DI36am++5/3gMgh02QnzpYigrwrW6s+QpU0mHf09/iA4wjTu21UUxodyV7ZCetV5MiDhaN/A==}
+    engines: {node: '>=20'}
+
+  plist@3.1.0:
+    resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
+    engines: {node: '>=10.4.0'}
+
+  resedit@3.0.1:
+    resolution: {integrity: sha512-edFP9lS/i/nmRuZ/cbfJJvltCXrSJccjf0QackceG/Aj583GM6cmnF+NU+tSRCDRkfGkp8PlNIoTGmmKjO1nxw==}
+    engines: {node: '>=20'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -161,6 +186,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
 snapshots:
 
   '@electron/asar@4.0.1':
@@ -184,6 +213,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@xmldom/xmldom@0.8.11': {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -195,6 +226,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
+
+  base64-js@1.5.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -255,6 +288,18 @@ snapshots:
       lru-cache: 11.2.4
       minipass: 7.1.2
 
+  pe-library@2.0.1: {}
+
+  plist@3.1.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.11
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  resedit@3.0.1:
+    dependencies:
+      pe-library: 2.0.1
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -298,3 +343,5 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
+
+  xmlbuilder@15.1.1: {}

--- a/utils.js
+++ b/utils.js
@@ -279,7 +279,7 @@ See https://github.com/m-obeid/signal-styler/issues/1#issuecomment-3726382244 fo
 			
 	    // get sha256 value first
         proc = spawnSync(path.join(appDir, "Contents", "MacOS", "Signal"), [], {
-            cwd: path.dirname(exePath),
+            cwd: path.dirname(appDir),
             encoding: "utf8"
         });
         stdout = (proc.stdout || "") + (proc.stderr || "");

--- a/utils.js
+++ b/utils.js
@@ -256,7 +256,7 @@ class Utils {
       case "darwin":
         // macOS makes this easier
         // Simply edit the Info.plist file and resign the app with codesign (ad-hoc)
-        const appDir = isUnassumedPath
+        const appDir = isAssumedPath
           ? this.asarPath.replace(
               "Contents/Resources/app.asar",
               ""
@@ -274,7 +274,10 @@ The SHA256 hash you need is shown when you run Signal from Terminal.
 See https://github.com/m-obeid/signal-styler/issues/1#issuecomment-3726382244 for more information.`,
           }; // user chose custom asar path, can't patch
 
-	// get sha256 value first
+		// on mac, we need to do codesign first, otherwisw we can't even run the app to get the key
+        execSync("codesign --force --deep --sign - " + appDir.replaceAll(" ", "\\ "));
+			
+	    // get sha256 value first
         proc = spawnSync(path.join(appDir, "Contents", "MacOS", "Signal"), [], {
             cwd: path.dirname(exePath),
             encoding: "utf8"
@@ -292,7 +295,7 @@ See https://github.com/m-obeid/signal-styler/issues/1#issuecomment-3726382244 fo
           match[1];
         fs.writeFileSync(infoPlistPath, plist.build(infoPlist));
 
-        // resign app with codesign
+        // resign app with codesign again, not sure if its neccesary but i suppose it wouldn't hurt
         execSync("codesign --force --deep --sign - " + appDir.replaceAll(" ", "\\ "));
         break;
       case "win32":


### PR DESCRIPTION
This fixes a bug where after patching, Signal won't launch because Electron's integrity check hasn't gotten updated to the new hash. Additionally includes general fixes for Windows systems.

Windows and macOS were affected